### PR TITLE
Fix typos and link to go-libsass

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 # go-run-sass
 
-A simple command line tool wrapper to generate css using `go-libsass` which otherwise recompiles the whole library when simply
-imported as [github.com/wellington/go-libsass](github.com/wellington/go-libsass). The other workarounds are explained in go-libsass README. 
+A simple command line tool wrapper to generate css using `go-libsass`, which otherwise recompiles the whole library when simply
+imported as [`github.com/wellington/go-libsass`](https://github.com/wellington/go-libsass). The other workarounds are explained in go-libsass README. 
 
 ## Installation
 


### PR DESCRIPTION
Title says it all. This adds a comma where needed, fixes the URL to `go-libsass` and styles the link to be inline code.